### PR TITLE
Add support for 3 more quests

### DIFF
--- a/db/LocaleEN.json
+++ b/db/LocaleEN.json
@@ -372,9 +372,9 @@
 
     "6573382e557ff128bf3da536": {
         "QuestName": "Developer Secrets Part 2",
-        "IsKeyRequired": false,
-        "RequiredKey": "",
-        "OptionalKey": "Relaxation room key"
+        "IsKeyRequired": true,
+        "RequiredKey": "Relaxation room key",
+        "OptionalKey": ""
     },
 
     "6573397ef3f8344c4575cd87": {

--- a/db/LocaleEN.json
+++ b/db/LocaleEN.json
@@ -342,6 +342,13 @@
         "OptionalKey": ""
     },
 
+    "64f5e20652fc01298e2c61e3": {
+        "QuestName": "Beyond The RedMeat P1",
+        "IsKeyRequired": false,
+        "RequiredKey": "",
+        "OptionalKey": "Beluga restaurant director key"
+    },
+
     "64f6aafd67e11a7c6206e0d0": {
         "QuestName": "Beyond The RedMeat P2",
         "IsKeyRequired": true,
@@ -361,5 +368,19 @@
         "IsKeyRequired": true,
         "RequiredKey": "\"Negotiation\" room key",
         "OptionalKey": ""
+    },
+
+    "6573382e557ff128bf3da536": {
+        "QuestName": "Developer Secrets Part 2",
+        "IsKeyRequired": false,
+        "RequiredKey": "",
+        "OptionalKey": "Relaxation room key"
+    },
+
+    "6573397ef3f8344c4575cd87": {
+        "QuestName": "Properties All Around",
+        "IsKeyRequired": false,
+        "RequiredKey": "",
+        "OptionalKey": "Real estate agency office room key"
     }
 }


### PR DESCRIPTION
Adds support for three quests.

**Quests w/ Required Keys:**

- Developer's Secrets P2: https://escapefromtarkov.fandom.com/wiki/Developer%27s_Secrets_-_Part_2

**Quests w/ Optional Keys:**

- Beyond the Red Meat P1: https://escapefromtarkov.fandom.com/wiki/Beyond_the_Red_Meat_-_Part_1
- Properties All Around: https://escapefromtarkov.fandom.com/wiki/Properties_All_Around