### PR TITLE
Cross-platform path support

### DIFF
--- a/src/InstanceManager.ts
+++ b/src/InstanceManager.ts
@@ -25,10 +25,10 @@ export class InstanceManager
     public modName: string;
     public debug: boolean;
     // Useful Paths
-    public modPath: string = path.join(process.cwd(), "\\user\\mods\\TarkovTools\\");
-    public dbPath: string = path.join(process.cwd(), "\\user\\mods\\TarkovTools\\database");
-    public profilePath: string = path.join(process.cwd(), "\\user\\profiles");
-    public cachePath: string = path.resolve(__dirname, "..\\config\\cache.json");
+    public modPath: string = path.join(process.cwd(), "user", "mods", "TarkovTools");
+    public dbPath: string = path.join(process.cwd(), "user", "mods", "TarkovTools", "database");
+    public profilePath: string = path.join(process.cwd(), "user", "profiles");
+    public cachePath: string = path.join(__dirname, "..", "config", "cache.json");
 
     // Instances
     public container: DependencyContainer;
@@ -40,7 +40,7 @@ export class InstanceManager
     public staticRouter: StaticRouterModService;
     //#endregion
 
-    //#region Acceessible in or after postDBLoad
+    //#region Accessible in or after postDBLoad
     public database: IDatabaseTables;
     public customItem: CustomItemService;
     public imageRouter: ImageRouter;
@@ -54,9 +54,6 @@ export class InstanceManager
     // Call at the start of the mods postDBLoad method
     public preAkiLoad(container: DependencyContainer, mod: string): void
     {
-
-        
-
         this.modName = mod;
 
         this.container = container;

--- a/src/InstanceManager.ts
+++ b/src/InstanceManager.ts
@@ -28,7 +28,7 @@ export class InstanceManager
     public modPath: string = path.join(process.cwd(), "user", "mods", "TarkovTools");
     public dbPath: string = path.join(process.cwd(), "user", "mods", "TarkovTools", "database");
     public profilePath: string = path.join(process.cwd(), "user", "profiles");
-    public cachePath: string = path.join(__dirname, "..", "config", "cache.json");
+    public cachePath: string = path.join(path.dirname(__filename), "..", "config", "cache.json");
 
     // Instances
     public container: DependencyContainer;


### PR DESCRIPTION
Switch `path.join` and `path.resolve` calls with individual arguments to let it pick the most OS-appropriate path separator; fixes compatibility issues for downstream mods.

For example, Linux hosts would end up with clobbered paths for `cache.json`, such as: `user\\mods\\ExpandedTaskText\\src\\..\\config\\cache.json`

Image courtesy of Corter from [mod sync](https://github.com/c-orter/modsync):

![image](https://github.com/CJ-SPT/Expanded-Task-Text/assets/4713229/bb01d964-d0d9-4152-8ca0-0ad720b2ef76)
